### PR TITLE
fix(README): Broken Contributing link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -102,7 +102,7 @@ We maintain OrbitDB accounts on these registries:
 
 Please contribute! [Dive into the issues](https://github.com/orbitdb/orbitdb/issues)!
 
-Check out our [contributing document](contributing.md) for more information on how we work, and about contributing in general. Please be aware that all interactions related to OrbitDB are subject to the OrbitDB [Code of Conduct](CODE_OF_CONDUCT.md).
+Check out our [contributing document](/CONTRIBUTING.md) for more information on how we work, and about contributing in general. Please be aware that all interactions related to OrbitDB are subject to the OrbitDB [Code of Conduct](CODE_OF_CONDUCT.md).
 
 Small note: If editing the README, please conform to the [standard-readme](https://github.com/RichardLitt/standard-readme) specification.
 


### PR DESCRIPTION
Hello 👋 

Just found a broken link to your contributing guide in the organization README while reading it 😄

![image](https://user-images.githubusercontent.com/49811529/220351145-745f7a66-a59b-4db5-bc85-23a9526f7002.png)
